### PR TITLE
Updated Aqara Button device driver - adds model WXKG12LM

### DIFF
--- a/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
@@ -58,19 +58,19 @@ metadata {
 		// Aqara Button - original revision - model WXKG11LM
 		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,FFFF,0006", outClusters: "0000,0004,FFFF", manufacturer: "LUMI", model: "lumi.sensor_switch.aq2"
 		// Aqara Button - new revision - model WXKG12LM
-		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,0001,0006,0012", outClusters: "0000", manufacturer: "LUMI", model: "lumi.sensor_switch.aq3", deviceJoinName: "Aqara Button WXKG12LM"
+		fingerprint endpointId: "01", profileId: "0104", inClusters: "0000,0012,0006,0001", outClusters: "0000", manufacturer: "LUMI", model: "lumi.sensor_switch.aq3"
 
 		command "resetBatteryReplacedDate"
 	}
 
 	preferences {
 		//Button Config
-		input "releaseTime", "number", title: "MODEL WXKG11LM ONLY: Delay after a single press to send 'release' (button 0 pushed) event (default 2 seconds)", description: "", range: "1..60"
+		input "releaseTime", "number", title: "MODEL WXKG11LM ONLY: Delay after a single press to send 'release' (button 0 pushed) event", description: "Default = 2.0 seconds", range: "1..60"
 		//Battery Voltage Range
-		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.7)", type: "decimal", range: "2..2.7", defaultValue: 2.5
-		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.8 to 3.4)", type: "decimal", range: "2.8..3.4", defaultValue: 3
+		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.7)", description: "Default = 2.5 Volts", type: "decimal", range: "2..2.7"
+		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.8 to 3.4)", description: "Default = 3.0 Volts", type: "decimal", range: "2.8..3.4"
 		//Logging Message Config
-		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: "", defaultValue: true
+		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
 		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
 	}
 }
@@ -153,9 +153,9 @@ private parse12LMMessage(value) {
 	def coreType = ["", "Pressed", "Pressed", "Held", "Released", "Pressed"]
 	def buttonNum = [1, 1, 2, 1, 0, 3]
 	displayInfoLog("Button was ${messageType[value]} (Button ${buttonNum[value]} $eventType)")
-	updateCoREEvent(coreType)
+	updateCoREEvent(coreType[value])
 	return [
-		name: 'pushed',
+		name: eventType,
 		value: buttonNum[value],
 		isStateChange: true,
 		descriptionText: "Button was ${messageType[value]}"
@@ -235,8 +235,6 @@ def hold() {
 def installed() {
 	state.prefsSetCount = 0
 	displayInfoLog("Installing")
-	if (!device.currentState('batteryLastReplaced')?.value)
-		resetBatteryReplacedDate(true)
 	sendEvent(name: "numberOfButtons", value: 4)
 }
 
@@ -246,15 +244,15 @@ def configure() {
 	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
 	sendEvent(name: "numberOfButtons", value: 4)
+	state.prefsSetCount = 1
 	return
 }
 
 // updated() runs every time user saves preferences
 def updated() {
-	displayInfoLog(": Updating preference settings")
-	state.prefsSetCount = 1
+	displayInfoLog("Updating preference settings")
 	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
-	displayInfoLog(": Info message logging enabled")
-	displayDebugLog(": Debug message logging enabled")
+	displayInfoLog("Info message logging enabled")
+	displayDebugLog("Debug message logging enabled")
 }

--- a/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
@@ -235,7 +235,7 @@ def hold() {
 def installed() {
 	state.prefsSetCount = 0
 	displayInfoLog("Installing")
-	sendEvent(name: "numberOfButtons", value: 3)
+	sendEvent(name: "numberOfButtons", value: 4)
 }
 
 // configure() runs after installed() when a sensor is paired or reconnected
@@ -244,7 +244,7 @@ def configure() {
 	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
 	sendEvent(name: "numberOfButtons", value: 3)
-	displayInfoLog("Number of buttons = 3")
+	displayInfoLog("Number of buttons = 4 (model WXKG12LM only uses buttons 1-3)")
 	state.prefsSetCount = 1
 	return
 }

--- a/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
@@ -1,7 +1,7 @@
 /**
- *  Xiaomi Aqara Button - model WXKG11LM
+ *  Xiaomi Aqara Button - models WXKG11LM / WXKG12LM
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.2
+ *  Version 0.5
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -14,10 +14,21 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  *  Based on SmartThings device handler code by a4refillpad
- *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, veeceeoh, & xtianpaiva
  *  Reworked and additional code for use with Hubitat Elevation hub by veeceeoh
  *
- *  Known issues:
+ *  Notes on capabilities of the different models:
+ *  Models WXKG11LM
+ *    - Only single press is supported, sent as button 1 "pushed" event
+ *  Model WXKG11LM:
+ *    - Single click results in button 1 "pushed" event
+ *    - Hold for longer than 400ms results in button 1 "held" event
+ *    - Double click results in button 2 "pushed" event
+ *    - Shaking the button results in button 3 "pushed" event
+ *    - Single or double click results in custom "lastPressedCoRE" event for webCoRE use
+ *    - Release of button results in "lastReleasedCoRE" event for webCoRE use
+ *
+  *  Known issues:
  *  + Xiaomi devices send reports based on changes, and a status report every 50-60 minutes. These settings cannot be adjusted.
  *  + The battery level / voltage is not reported at pairing. Wait for the first status report, 50-60 minutes after pairing.
  *    However, the Aqara Button battery level can be retrieved immediately with a short-press of the reset button.
@@ -34,30 +45,32 @@
 metadata {
 	definition (name: "Xiaomi Aqara Button", namespace: "veeceeoh", author: "bspranger") {
 		capability "PushableButton"
+		capability "HoldableButton"
 		capability "Sensor"
 		capability "Battery"
 
 		attribute "lastCheckin", "String"
-		attribute "lastCheckinDate", "String"
 		attribute "batteryLastReplaced", "String"
+		attribute "buttonPressed", "String"
+		attribute "buttonHeld", "String"
+		attribute "buttonReleased", "String"
 
-		// this fingerprint is identical to the one for Xiaomi "Aqara" Door/Window Sensor except for model name
+		// Aqara Button - original revision - model WXKG11LM
 		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,FFFF,0006", outClusters: "0000,0004,FFFF", manufacturer: "LUMI", model: "lumi.sensor_switch.aq2"
+		// Aqara Button - new revision - model WXKG12LM
+		fingerprint endpointId: "01", profileId: "0104", deviceId: "5F01", inClusters: "0000,0001,0006,0012", outClusters: "0000", manufacturer: "LUMI", model: "lumi.sensor_switch.aq3", deviceJoinName: "Aqara Button WXKG12LM"
 
 		command "resetBatteryReplacedDate"
 	}
 
 	preferences {
 		//Button Config
-		input "ReleaseTime", "number", title: "Minimum time in seconds for a press to clear (default 2)", description: "", range: "1..60", defaultValue: 2
-		input name: "PressType", type: "enum", options: ["Momentary", "Toggle"], title: "Momentary or toggle? ", defaultValue: "Momentary"
-		//Date & Time Config
-		input name: "dateformat", type: "enum", title: "Date Format for lastCheckin: US (MDY), UK (DMY), or Other (YMD)", description: "", options:["US","UK","Other"]
-		input name: "clockformat", type: "bool", title: "Use 24 hour clock", description: ""
-		//Battery Reset Config
+		input "releaseTime", "number", title: "MODEL WXKG11LM ONLY: Delay after a single press to send 'release' (button 0 pushed) event (default 2 seconds)", description: "", range: "1..60"
+		//Battery Voltage Range
 		input name: "voltsmin", title: "Min Volts (A battery needs replacing at ___ volts, Range 2.0 to 2.7)", type: "decimal", range: "2..2.7", defaultValue: 2.5
 		input name: "voltsmax", title: "Max Volts (A battery is at 100% at ___ volts, range 2.8 to 3.4)", type: "decimal", range: "2.8..3.4", defaultValue: 3
-		input name: "debugLogging", type: "bool", title: "Display debug log messages", description: "", defaultValue: false
+		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: "", defaultValue: true
+		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
 	}
 }
 
@@ -66,100 +79,100 @@ def parse(String description) {
 	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
-	displayDebugLog("Parsing description: ${description}")
-
-	// Determine current time and date in the user-selected date format and clock style
-	def now = formatDate()
-	def nowDate = new Date(now).getTime()
-
-	// lastCheckin and lastPressedDate can be used to determine if the sensor is "awake" and connected
-	sendEvent(name: "lastCheckin", value: now)
-	sendEvent(name: "lastCheckinDate", value: nowDate)
-
 	Map map = [:]
+
+	// lastCheckin can be used with webCoRE
+	sendEvent(name: "lastCheckin", value: now())
+
+	displayDebugLog("Parsing message: ${description}")
 
 	// Send message data to appropriate parsing function based on the type of report
 	if (cluster == "0006") {
-		map = parseButtonMessage(attrId, Integer.parseInt(valueHex))
+		// Model WXKG11LM only
+		map = parse11LMMessage(attrId, Integer.parseInt(valueHex))
+	} else if (cluster == "0012") {
+		// Model WXKG12LM only
+		map = parse12LMMessage(Integer.parseInt(valueHex[2..3],16))
 	} else if (cluster == "0000" & attrId == "0005") {
-		displayDebugLog("Reset button was short-pressed")
+		displayInfoLog("Reset button was short-pressed")
+		// Parse battery level from longer type of announcement message
 		map = (valueHex.size() > 60) ? parseBattery(valueHex.split('FF42')[1]) : [:]
 	} else if (cluster == "0000" & (attrId == "FF01" || attrId == "FF02")) {
+		// Parse battery level from hourly announcement message
 		map = (valueHex.size() > 30) ? parseBattery(valueHex) : [:]
 	} else if (!(cluster == "0000" & attrId == "0001")) {
-		displayDebugLog("Unable to parse ${description}")
+		displayDebugLog("Unable to parse message")
 	}
 
-	if (map) {
-		displayDebugLog("${map.descriptionText}")
+	if (map != [:]) {
+		displayDebugLog("Creating event $map")
 		return createEvent(map)
 	} else
 		return [:]
 }
 
-// Parse button message (press, double-click, triple-click, quad-click, and release)
-private parseButtonMessage(attrId, Value){
-    def result = [:]
+// Parse WXKG11LM button message (press, double-click, triple-click, quad-click, and release)
+private parse11LMMessage(attrId, value){
+	def result = [:]
+	releaseTime = releaseTime ? releaseTime : 2
 
-    if ((attrId=="0000") && (Value==1001))
-    {
-        if (PressType == "Toggle")
-        {
-            if ((state.button != "pushed") && (state.button != "released"))
-            {
-                state.button = "released"
-            }
-            if (state.button == "released")
-            {
-                result = getContactResult(1)
-                state.button = "pushed"
-            }
-            else
-            {
-                result = getContactResult(0)
-                state.button = "released"
-            }
-        }
-        else
-        {
-            result = getContactResult(1)
-            state.button = "pushed"
-            runIn(ReleaseTime, ReleaseButton)
-        }
-    }
-    else if (attrId=="8000")
-    {
-        result = getContactResult(Value)
-    }
-    
-     return result
+	if ((attrId == "0000") && (value == 1001 || value == 1000)) {
+		result = map11LMEvent(1)
+		runIn(releaseTime, releaseButton)
+	} else if (attrId=="8000") {
+		result = map11LMEvent(value)
+	}
+	return result
 }
 
-private Map getContactResult(value) {
-    def clickType = ["released", "single clicked", "double clicked", "triple clicked", "quadruple clicked"]
-    if (value <= 4)
-    {
-        return [
-            name: 'pushed',
-            value: value,
-            isStateChange: true,
-            descriptionText: "Button was ${clickType[value]}"
-        ]
-    }
-    else
-    {
-        return [:]
-    }
+// Build event map based on type of WXKG11LM click
+private Map map11LMEvent(value) {
+	def clickType = ["released", "single-clicked", "double-clicked", "triple-clicked", "quadruple-clicked"]
+	def coreType = (value == 0) ? "Released" : "Pressed"
+	if (value <= 4) {
+		displayInfoLog("Button was ${clickType[value]} (Button $value pushed)")
+		updateCoREEvent(coreType)
+		return [
+			name: 'pushed',
+			value: value,
+			isStateChange: true,
+			descriptionText: "Button was ${clickType[value]}"
+		]
+	} else {
+		return [:]
+	}
 }
 
-def ReleaseButton()
-{
-    def result = [:]
-    displayDebugLog("Calling Release Button")
-    result = getContactResult(0)
-    state.button = "released"
-    displayDebugLog("${result.descriptionText}")
-    sendEvent(result)
+// Build event map based on type of WXKG12LM action
+private parse12LMMessage(value) {
+	// Button message values (as integer): 1 = push, 2 = double-click, 16 = hold, 17 = release, 18 = shake
+	value = (value < 3) ? value : (value - 13)
+	def messageType = ["", "single-clicked", "double-clicked", "held", "released", "shaken"]
+	def eventType = (value == 3) ? "held" : "pushed"
+	def coreType = ["", "Pressed", "Pressed", "Held", "Released", "Pressed"]
+	def buttonNum = [1, 1, 2, 1, 0, 3]
+	displayInfoLog("Button was ${messageType[value]} (Button ${buttonNum[value]} $eventType)")
+	updateCoREEvent(coreType)
+	return [
+		name: 'button',
+		value: eventType,
+		data: [buttonNumber: buttonNum[value]],
+		descriptionText: "Button was ${messageType[value]}",
+		isStateChange: true
+	]
+}
+
+// Generate buttonPressed, buttonHeld, or buttonReleased event for webCoRE use
+def updateCoREEvent(coreType) {
+	displayDebugLog("Setting button${coreType} to current date/time for webCoRE")
+	sendEvent(name: "button${coreType}", value: now(), descriptionText: "Updated button${coreType} (webCoRE)")
+}
+
+def releaseButton() {
+	def result = [:]
+	displayDebugLog("Calling button release after delay of ${releaseTime = releaseTime ? releaseTime : 2} seconds")
+	result = map11LMEvent(0)
+	sendEvent(result)
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
@@ -178,97 +191,70 @@ private parseBattery(description) {
 	def maxVolts = voltsmax ? voltsmax : 3.0
 	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
 	def roundedPct = Math.min(100, Math.round(pct * 100))
+	def descText = "Battery level is ${roundedPct}% (${rawVolts} Volts)"
+	displayInfoLog(descText)
 	def result = [
 		name: 'battery',
 		value: roundedPct,
 		unit: "%",
 		isStateChange: true,
-		descriptionText: "Battery level is ${roundedPct}%, raw battery is ${rawVolts}V"
+		descriptionText: descText
 	]
 	return result
-}
-
-//Reset the batteryLastReplaced date to current date
-def resetBatteryReplacedDate(paired) {
-	def now = formatDate(true)
-	def newlyPaired = paired ? " for newly paired sensor" : ""
-	sendEvent(name: "batteryLastReplaced", value: now)
-	displayDebugLog("Setting Battery Last Replaced to current date${newlyPaired}")
 }
 
 private def displayDebugLog(message) {
 	if (debugLogging) log.debug "${device.displayName}: ${message}"
 }
 
+private def displayInfoLog(message) {
+	if (infoLogging || state.prefsSetCount != 1)
+		log.info "${device.displayName}: ${message}"
+}
+
+//Reset the batteryLastReplaced date to current date
+def resetBatteryReplacedDate(paired) {
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryLastReplaced", value: new Date())
+	displayInfoLog("Setting Battery Last Replaced to current date${newlyPaired}")
+}
+
 // this call is here to avoid Groovy errors when the Push command is used
 // it is empty because the Xioami button is non-controllable
 def push() {
-	displayDebugLog("Fo' shizzle this button can't be controlled!")
+	displayDebugLog("No action taken on Push Command. This button cannot be controlled.")
 }
 
 // this call is here to avoid Groovy errors when the Hold command is used
 // it is empty because the Xioami button is non-controllable
 def hold() {
-	displayDebugLog("Fo' shizzle this button can't be controlled!")
+	displayDebugLog("No action taken on Hold Command. This button cannot be controlled!")
 }
 
 // installed() runs just after a sensor is paired
 def installed() {
-	log.debug "${device.displayName}: Installing"
-	sendEvent(name: "numberOfButtons", value: 2)
-	state.countdownActive = false
-	if (!batteryLastReplaced)
+	state.prefsSetCount = 0
+	displayInfoLog("Installing")
+	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
+	sendEvent(name: "numberOfButtons", value: 4)
 }
 
 // configure() runs after installed() when a sensor is paired or reconnected
 def configure() {
-	log.debug "${device.displayName}: Configuring"
-	sendEvent(name: "numberOfButtons", value: 2)
-	log.debug "${device.displayName}: Number of buttons = 2"
-	state.countdownActive = false
-	if (!batteryLastReplaced)
+	displayInfoLog("Configuring")
+	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
+	sendEvent(name: "numberOfButtons", value: 4)
 	return
 }
 
 // updated() runs every time user saves preferences
 def updated() {
-	displayDebugLog("Updating preference settings")
-	sendEvent(name: "numberOfButtons", value: 2)
-	state.countdownActive = false
-}
-
-def formatDate(batteryReset) {
-	def correctedTimezone = ""
-	def timeString = clockformat ? "HH:mm:ss" : "h:mm:ss aa"
-
-	// If user's hub timezone is not set, display error messages in log and events log, and set timezone to GMT to avoid errors
-	if (!(location.timeZone)) {
-		correctedTimezone = TimeZone.getTimeZone("GMT")
-		log.error "${device.displayName}: Time Zone not set, so GMT was used. Please set up your Hubitat hub location."
-		sendEvent(name: "error", value: "", descriptionText: "ERROR: Time Zone not set, so GMT was used. Please set up your Hubitat hub location.")
-	}
-	else {
-		correctedTimezone = location.timeZone
-	}
-
-	if (dateformat == "US" || dateformat == "" || dateformat == null) {
-		if (batteryReset)
-			return new Date().format("MMM dd yyyy", correctedTimezone)
-		else
-			return new Date().format("EEE MMM dd yyyy ${timeString}", correctedTimezone)
-	}
-	else if (dateformat == "UK") {
-		if (batteryReset)
-			return new Date().format("dd MMM yyyy", correctedTimezone)
-		else
-			return new Date().format("EEE dd MMM yyyy ${timeString}", correctedTimezone)
-	}
-	else {
-		if (batteryReset)
-			return new Date().format("yyyy MMM dd", correctedTimezone)
-		else
-			return new Date().format("EEE yyyy MMM dd ${timeString}", correctedTimezone)
-	}
+	displayInfoLog(": Updating preference settings")
+	state.prefsSetCount = 1
+	if (!device.currentState('batteryLastReplaced')?.value)
+		resetBatteryReplacedDate(true)
+	displayInfoLog(": Info message logging enabled")
+	displayDebugLog(": Debug message logging enabled")
 }

--- a/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
@@ -235,7 +235,7 @@ def hold() {
 def installed() {
 	state.prefsSetCount = 0
 	displayInfoLog("Installing")
-	sendEvent(name: "numberOfButtons", value: 4)
+	sendEvent(name: "numberOfButtons", value: 3)
 }
 
 // configure() runs after installed() when a sensor is paired or reconnected
@@ -243,7 +243,8 @@ def configure() {
 	displayInfoLog("Configuring")
 	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
-	sendEvent(name: "numberOfButtons", value: 4)
+	sendEvent(name: "numberOfButtons", value: 3)
+	displayInfoLog("Number of buttons = 3")
 	state.prefsSetCount = 1
 	return
 }
@@ -253,6 +254,7 @@ def updated() {
 	displayInfoLog("Updating preference settings")
 	if (!device.currentState('batteryLastReplaced')?.value)
 		resetBatteryReplacedDate(true)
+	sendEvent(name: "numberOfButtons", value: 3)
 	displayInfoLog("Info message logging enabled")
 	displayDebugLog("Debug message logging enabled")
 }

--- a/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
@@ -155,11 +155,10 @@ private parse12LMMessage(value) {
 	displayInfoLog("Button was ${messageType[value]} (Button ${buttonNum[value]} $eventType)")
 	updateCoREEvent(coreType)
 	return [
-		name: 'button',
-		value: eventType,
-		data: [buttonNumber: buttonNum[value]],
-		descriptionText: "Button was ${messageType[value]}",
-		isStateChange: true
+		name: 'pushed',
+		value: buttonNum[value],
+		isStateChange: true,
+		descriptionText: "Button was ${messageType[value]}"
 	]
 }
 

--- a/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-button-hubitat.src/xiaomi-aqara-button-hubitat.groovy
@@ -67,8 +67,9 @@ metadata {
 		//Button Config
 		input "releaseTime", "number", title: "MODEL WXKG11LM ONLY: Delay after a single press to send 'release' (button 0 pushed) event (default 2 seconds)", description: "", range: "1..60"
 		//Battery Voltage Range
-		input name: "voltsmin", title: "Min Volts (A battery needs replacing at ___ volts, Range 2.0 to 2.7)", type: "decimal", range: "2..2.7", defaultValue: 2.5
-		input name: "voltsmax", title: "Max Volts (A battery is at 100% at ___ volts, range 2.8 to 3.4)", type: "decimal", range: "2.8..3.4", defaultValue: 3
+		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.7)", type: "decimal", range: "2..2.7", defaultValue: 2.5
+		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.8 to 3.4)", type: "decimal", range: "2.8..3.4", defaultValue: 3
+		//Logging Message Config
 		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: "", defaultValue: true
 		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
 	}


### PR DESCRIPTION
**Changes**:
• **added compatibility with Aqara Button model WXKG12LM**, which supports single-click, double-click, hold, release, and shake actions
• added custom `buttonPressed`, `buttonHeld`, & `buttonReleased` events for webCoRE use
• removed toggle mode for model WXKG11LM, because Rule Machine, webCoRE, etc. already have toggle switch actions
• changed releaseTime preference description text for clarity and to specify it only applies to model WXKG11LM
• added `value: 1000` for `cluster: 0006, attrId: 0000` messages to be parsed as model WXKG11LM single click
• assigned some log messages to be "informational" log type
• added "enable info logging" toggle preference
• added / edited log messages for clarity
• changed `lastCheckin` event to use Epoch Time stamp (for use with webCoRE)
• removed `lastCheckinDate` because it serves no real purpose on Hubitat
• changed `resetBatteryReplacedDate()` to use `new Date()` for date/time stamp
• removed `formatDate()` function because it is not used anymore
• removed date format and 24 hour clock settings because they are not used anymore
• changed `numberOfButtons` to 4 on install / configure