### PR TITLE
New Aqara Wireless Smart Light Switch device driver

### DIFF
--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  2016 & 2018 revisions of models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7b
+ *  Version 0.7.1b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -114,7 +114,7 @@ def parse(String description) {
 		// Model WXKG03LM: endpoint 1 = button pushed
 		// Model WXKG02LM: endpoint 1 = left button pushed, 2 = right button pushed, 3 = both pushed
 		// Both models: valueHex 0 = held, 1 = pushed, 2 = double-tapped
-		map = parse18Message(Integer.parseInt(endpoint, valueHex[2..3],16))
+		map = parse18Message(Integer.parseInt(endpoint), Integer.parseInt(valueHex[2..3],16))
 	} else if (cluster == "0000" & attrId == "0005") {
 		displayDebugLog "Button was long-pressed"
 		// Parse battery level from longer type of announcement message
@@ -158,7 +158,6 @@ private Map parse16Message(buttonNum) {
 
 // Build event map based on revision 2018 button press
 private parse18Message(buttonNum, pressType) {
-	// Button press type message values (as integer): value 0 = held, 1 = pushed, 2 = double-tapped
 	def whichButton = [1: ${(state.numOfButtons == 1) ? "Button" : "Left button"}, 2: "Right button", 3: "Both buttons"]
 	def messageType = ["held", "pressed", "double-tapped"]
 	def eventType = ["held", "pushed", "doubleTapped"]

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  Models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.52b
+ *  Version 0.55b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -114,7 +114,7 @@ private Map parse02LMMessage(value) {
 	def pushType = ["", "Left", "Right", "Both"]
 	def descText = "${pushType[value]} button${(value == 3) ? "s" : ""} pressed (Button $value pushed)"
 	displayInfoLog(descText)
-	updateCoREEvent("Pressed")
+	updateDateTimeStamp("Pressed")
 	return [
 		name: 'pushed',
 		value: value,
@@ -128,9 +128,9 @@ private parse03LMMessage(value) {
 	// Button message values (as integer): value 0 = held, 1 = pushed, 2 = double-tapped
 	def messageType = ["held", "pressed", "double-tapped"]
 	def eventType = ["held", "pushed", "doubleTapped"]
-	def coreType = ["Held", "Pressed", "DoubleTapped"]
+	def timeStampType = ["Held", "Pressed", "DoubleTapped"]
 	displayInfoLog("Button was ${messageType[value]}")
-	updateCoREEvent(coreType[value])
+	updateDateTimeStamp(timeStampType[value])
 	return [
 		name: eventType[value],
 		value: 1,
@@ -139,11 +139,11 @@ private parse03LMMessage(value) {
 	]
 }
 
-// Generate buttonPressed(Time), buttonHeld(Time), or buttonReleased(Time) event for webCoRE/dashboard use
-def updateCoREEvent(coreType) {
-	displayDebugLog("Setting button${coreType} & button${coreType}Time to current date/time for webCoRE/dashboard use")
-	sendEvent(name: "button${coreType}", value: now(), descriptionText: "Updated button${coreType} (webCoRE)")
-	sendEvent(name: "button${coreType}Time", value: new Date().toLocaleString(), descriptionText: "Updated button${coreType}Time")
+// Generate buttonPressed(Time), buttonHeld(Time), or buttonReleased(Time) event for webCoRE/Hubitat dashboard use
+def updateDateTimeStamp(timeStampType) {
+	displayDebugLog("Setting button${timeStampType} & button${timeStampType}Time to current date/time for webCoRE/dashboard use")
+	sendEvent(name: "button${timeStampType}", value: now(), descriptionText: "Updated button${timeStampType} (webCoRE)")
+	sendEvent(name: "button${timeStampType}Time", value: new Date().toLocaleString(), descriptionText: "Updated button${timeStampType}Time")
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -1,0 +1,237 @@
+/*
+ *  Xiaomi Aqara Wireless Smart Light Switch
+ *  Models WXKG03LM (1 button) and WXKG02LM (2 buttons)
+ *  Device Driver for Hubitat Elevation hub
+ *  Version 0.5b
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  Based on SmartThings device handler code by a4refillpad
+ *  Reworked for use with Hubitat Elevation hub by gn0st1c with additional code by veeceeoh
+ *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, veeceeoh, & xtianpaiva
+ *
+ *  Notes on capabilities of the different models:
+ *  Model WXKG03LM (1 button):
+ *    - Single press results in button 1 "pushed" event
+ *    - Double click results in button 1 "doubleTapped" event
+ *    - Single click results in button 1 "held" event
+ *  Model WXKG02LM (2 button):
+ *    - Single click results in button 1 "pushed" event
+ *    - Hold for longer than 400ms results in button 1 "held" event
+ *
+ *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *
+ *  https://xiaomi-mi.com/sockets-and-sensors/xiaomi-aqara-smart-light-control-set
+ */
+
+metadata {
+	definition (name: "Xiaomi Aqara Dual Button Light Switch", namespace: "veeceeoh", author: "gn0st1c") {
+		capability "Battery"
+		capability "DoubleTapableButton"
+		capability "HoldableButton"
+		capability "PushableButton"
+		capability "Sensor"
+
+		attribute "lastCheckin", "String"
+		attribute "lastCheckinTime", "String"
+		attribute "batteryLastReplaced", "String"
+		attribute "buttonPressed", "String"
+		attribute "buttonPressedTime", "String"
+		attribute "buttonDoubleTapped", "String"
+		attribute "buttonDoubleTappedTime", "String"
+		attribute "buttonHeld", "String"
+		attribute "buttonHeldTime", "String"
+
+		// Aqara Wireless Smart Light Switch - one button - model WXKG03LM
+		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw1lu"
+		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw1"
+		// Aqara Wireless Smart Light Switch - two button - model WXKG02LM
+		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw2Un"
+		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw2"
+
+		command "resetBatteryReplacedDate"
+	}
+
+	preferences {
+		//Battery Voltage Range
+ 		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.9). Default = 2.9 Volts", description: "", type: "decimal", range: "2..2.9"
+ 		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.95 to 3.4). Default = 3.05 Volts", description: "", type: "decimal", range: "2.95..3.4"
+ 		//Logging Message Config
+		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
+		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
+	}
+}
+
+// Parse incoming device messages to generate events
+def parse(String description) {
+	def endpoint = description.split(",").find {it.split(":")[0].trim() == "endpoint"}?.split(":")[1].trim()
+	def cluster	= description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+	Map map = [:]
+
+	// lastCheckin can be used with webCoRE
+	sendEvent(name: "lastCheckin", value: now())
+	sendEvent(name: "lastCheckinTime", value: formatDate()
+
+	displayDebugLog("Parsing message: ${description}")
+
+	// Send message data to appropriate parsing function based on the type of report
+	if (cluster == "0006") {
+		// Parse Model WXKG02LM button press: endpoint 01 = left, 02 = right, 03 = both
+		map = parse02LMMessage(Integer.parseInt(endpoint))
+	} else if (cluster == "0012") {
+		// Parse Model WXKG03LM button message: value 0 = push, 1 = double-click, 2 = hold
+		map = parse03LMMessage(Integer.parseInt(valueHex[2..3],16))
+		}
+	} else if (cluster == "0000" & attrId == "0005") {
+		displayDebugLog "Reset button was short-pressed"
+		// Parse battery level from longer type of announcement message
+		map = (valueHex.size() > 60) ? parseBattery(valueHex.split('FF42')[1]) : [:]
+	} else if (cluster == "0000" & (attrId == "FF01" || attrId == "FF02")) {
+		// Parse battery level from hourly announcement message
+		map = (valueHex.size() > 30) ? parseBattery(valueHex) : [:]
+	} else if (!(cluster == "0000" & attrId == "0001")) {
+		displayDebugLog "Unable to parse ${description}"
+	}
+
+	if (map != [:]) {
+		displayDebugLog("Creating event $map")
+		return createEvent(map)
+	} else
+		return [:]
+}
+
+// Build event map based on type of WXKG02LM button press
+private Map parse02LMMessage(value) {
+	def pushType = ["", "Left", "Right", "Both"]
+	def descText = "${pushType[value]} button${(value == 3) ? "s" : ""} pressed (Button $value pushed)"
+	displayInfoLog(descText)
+	updateCoREEvent(coreType[value])
+	if (!(state.numOfButtons == 3))
+		init()
+	return [
+		name: 'pushed',
+		value: value,
+		isStateChange: true,
+		descriptionText: descText
+	]
+}
+
+// Build event map based on type of WXKG03LM button press
+private parse03LMMessage(value) {
+	// Button message values (as integer): 0 = push, 1 = double-click, 2 = hold
+	def messageType = ["pressed", "double-tapped", "held"]
+	def eventType = ["pushed", "doubleTapped", "held"]
+	def coreType = ["Pressed", "DoubleTapped", "Held"]
+	if (!(state.numOfButtons == 1)) {
+		sendEvent(name: "numberOfButtons", value: 1)
+		displayInfoLog("Number of buttons set to 1 for model WXKG03LM")
+		state.numOfButtons = 1
+	}
+	displayInfoLog("Button was ${messageType[value]}")
+	updateCoREEvent(coreType[value])
+	return [
+		name: eventType[value],
+		value: 1,
+		isStateChange: true,
+		descriptionText: "Button was ${messageType[value]}"
+	]
+}
+
+// Generate buttonPressed(Time), buttonHeld(Time), or buttonReleased(Time) event for webCoRE/dashboard use
+def updateCoREEvent(coreType) {
+	displayDebugLog("Setting button${coreType} & button${coreType}Time to current date/time for webCoRE/dashboard use")
+	sendEvent(name: "button${coreType}", value: now(), descriptionText: "Updated button${coreType} (webCoRE)")
+	sendEvent(name: "button${coreType}Time", value: formatDate(), descriptionText: "Updated button${coreType}Time")
+}
+
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
+private parseBattery(description) {
+	displayDebugLog("Battery parse string = ${description}")
+	def MsgLength = description.size()
+	def rawValue
+	for (int i = 4; i < (MsgLength-3); i+=2) {
+		if (description[i..(i+1)] == "21") { // Search for byte preceeding battery voltage bytes
+			rawValue = Integer.parseInt((description[(i+4)..(i+5)] + description[(i+2)..(i+3)]),16)
+			break
+		}
+	}
+	def rawVolts = rawValue / 1000
+	def minVolts = voltsmin ? voltsmin : 2.5
+	def maxVolts = voltsmax ? voltsmax : 3.0
+	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
+	def roundedPct = Math.min(100, Math.round(pct * 100))
+	def descText = "Battery level is ${roundedPct}% (${rawVolts} Volts)"
+	displayInfoLog(descText)
+	def result = [
+		name: 'battery',
+		value: roundedPct,
+		unit: "%",
+		isStateChange: true,
+		descriptionText: descText
+	]
+	return result
+}
+
+private def displayDebugLog(message) {
+	if (debugLogging) log.debug "${device.displayName}: ${message}"
+}
+
+private def displayInfoLog(message) {
+	if (infoLogging || state.prefsSetCount != 1)
+		log.info "${device.displayName}: ${message}"
+}
+
+//Reset the batteryLastReplaced date to current date
+def resetBatteryReplacedDate(paired) {
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryLastReplaced", value: new Date())
+	displayInfoLog("Setting Battery Last Replaced to current date${newlyPaired}")
+}
+
+// this call is here to avoid Groovy errors when the Push command is used
+// it is empty because the Xioami button is non-controllable
+def push() {
+	displayDebugLog("No action taken on Push Command. This button cannot be controlled.")
+}
+
+// installed() runs just after a sensor is paired
+def installed() {
+	state.prefsSetCount = 0
+	displayInfoLog("Installing")
+}
+
+// configure() runs after installed() when a sensor is paired or reconnected
+def configure() {
+	displayInfoLog("Configuring")
+	init()
+	state.prefsSetCount = 1
+	return
+}
+
+// updated() runs every time user saves preferences
+def updated() {
+	displayInfoLog("Updating preference settings")
+	init()
+	displayInfoLog("Info message logging enabled")
+	displayDebugLog("Debug message logging enabled")
+}
+
+def init() {
+	if (!device.currentState('batteryLastReplaced')?.value)
+		resetBatteryReplacedDate(true)
+	if (!state.numOfButtons) {
+		sendEvent(name: "numberOfButtons", value: 3)
+		displayInfoLog("Number of buttons set to 3 (on first button press of model WXKG03LM this will be changed to 1).")
+		state.numOfButtons = 3
+	}
+}

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  Models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.5b
+ *  Version 0.51b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -80,7 +80,7 @@ def parse(String description) {
 
 	// lastCheckin can be used with webCoRE
 	sendEvent(name: "lastCheckin", value: now())
-	sendEvent(name: "lastCheckinTime", value: formatDate())
+	sendEvent(name: "lastCheckinTime", value: new Date().toLocaleTimeString())
 
 	displayDebugLog("Parsing message: ${description}")
 
@@ -89,7 +89,7 @@ def parse(String description) {
 		// Parse Model WXKG02LM button press: endpoint 01 = left, 02 = right, 03 = both
 		map = parse02LMMessage(Integer.parseInt(endpoint))
 	} else if (cluster == "0012") {
-		// Parse Model WXKG03LM button message: value 0 = push, 1 = double-click, 2 = hold
+		// Parse Model WXKG03LM button message: value 0 = held, 1 = pushed, 2 = double-tapped
 		map = parse03LMMessage(Integer.parseInt(valueHex[2..3],16))
 	} else if (cluster == "0000" & attrId == "0005") {
 		displayDebugLog "Reset button was short-pressed"
@@ -127,10 +127,10 @@ private Map parse02LMMessage(value) {
 
 // Build event map based on type of WXKG03LM button press
 private parse03LMMessage(value) {
-	// Button message values (as integer): 0 = push, 1 = double-click, 2 = hold
-	def messageType = ["pressed", "double-tapped", "held"]
-	def eventType = ["pushed", "doubleTapped", "held"]
-	def coreType = ["Pressed", "DoubleTapped", "Held"]
+	// Button message values (as integer): value 0 = held, 1 = pushed, 2 = double-tapped
+	def messageType = ["held", "pressed", "double-tapped"]
+	def eventType = ["held", "pushed", "doubleTapped"]
+	def coreType = ["Held", "Pressed", "DoubleTapped"]
 	if (!(state.numOfButtons == 1)) {
 		sendEvent(name: "numberOfButtons", value: 1)
 		displayInfoLog("Number of buttons set to 1 for model WXKG03LM")
@@ -150,7 +150,7 @@ private parse03LMMessage(value) {
 def updateCoREEvent(coreType) {
 	displayDebugLog("Setting button${coreType} & button${coreType}Time to current date/time for webCoRE/dashboard use")
 	sendEvent(name: "button${coreType}", value: now(), descriptionText: "Updated button${coreType} (webCoRE)")
-	sendEvent(name: "button${coreType}Time", value: formatDate(), descriptionText: "Updated button${coreType}Time")
+	sendEvent(name: "button${coreType}Time", value: new Date().toLocaleTimeString(), descriptionText: "Updated button${coreType}Time")
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -114,7 +114,7 @@ private Map parse02LMMessage(value) {
 	def pushType = ["", "Left", "Right", "Both"]
 	def descText = "${pushType[value]} button${(value == 3) ? "s" : ""} pressed (Button $value pushed)"
 	displayInfoLog(descText)
-	updateCoREEvent(coreType[value])
+	updateCoREEvent("Pressed")
 	return [
 		name: 'pushed',
 		value: value,

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -94,12 +94,15 @@ def parse(String description) {
 	def endpoint = description.split(",").find {it.split(":")[0].trim() == "endpoint"}?.split(":")[1].trim()
 	def cluster	= description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+	def encoding = Integer.parseInt(description.split(",").find {it.split(":")[0].trim() == "encoding"}?.split(":")[1].trim(), 16)
 	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
 	Map map = [:]
 
-	if (!oldFirmware & valueHex != null)
-		// Reverse order of bytes in description's value hex string - required for Hubitat firmware 2.0.5 or newer
+	if (!oldFirmware & valueHex != null & encoding > 0x18 & encoding < 0x3e) {
+		displayDebugLog("Data type of payload is little-endian; reversing byte order")
+		// Reverse order of bytes in description's payload for LE data types - required for Hubitat firmware 2.0.5 or newer
 		valueHex = reverseHexString(valueHex)
+	}
 
 	displayDebugLog("Parsing message: ${description}")
 	displayDebugLog("Message payload: ${valueHex}")

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -166,8 +166,8 @@ private parseBattery(description) {
 		}
 	}
 	def rawVolts = rawValue / 1000
-	def minVolts = voltsmin ? voltsmin : 2.5
-	def maxVolts = voltsmax ? voltsmax : 3.0
+	def minVolts = voltsmin ? voltsmin : 2.9
+	def maxVolts = voltsmax ? voltsmax : 3.05
 	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
 	def roundedPct = Math.min(100, Math.round(pct * 100))
 	def descText = "Battery level is ${roundedPct}% (${rawVolts} Volts)"

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -80,7 +80,7 @@ def parse(String description) {
 
 	// lastCheckin can be used with webCoRE
 	sendEvent(name: "lastCheckin", value: now())
-	sendEvent(name: "lastCheckinTime", value: formatDate()
+	sendEvent(name: "lastCheckinTime", value: formatDate())
 
 	displayDebugLog("Parsing message: ${description}")
 
@@ -91,7 +91,6 @@ def parse(String description) {
 	} else if (cluster == "0012") {
 		// Parse Model WXKG03LM button message: value 0 = push, 1 = double-click, 2 = hold
 		map = parse03LMMessage(Integer.parseInt(valueHex[2..3],16))
-		}
 	} else if (cluster == "0000" & attrId == "0005") {
 		displayDebugLog "Reset button was short-pressed"
 		// Parse battery level from longer type of announcement message

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  2016 & 2018 revisions of models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.56b
+ *  Version 0.6b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -84,6 +84,8 @@ metadata {
  		//Logging Message Config
 		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
 		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
+		//Firmware 2.0.5 Compatibility Fix Config
+		input name: "oldFirmware", type: "bool", title: "DISABLE 2.0.5 firmware compatibility fix (for users of 2.0.4 or earlier)", description: ""
 	}
 }
 
@@ -94,6 +96,10 @@ def parse(String description) {
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
 	Map map = [:]
+
+	if (!oldFirmware & valueHex)
+		// Reverse order of bytes in description's value hex string - required for Hubitat firmware 2.0.5 or newer
+		valueHex = reverseHexString(valueHex)
 
 	// lastCheckinEpoch is for apps that can use Epoch time/date and lastCheckinTime can be used with Hubitat Dashboard
 	sendEvent(name: "lastCheckinEpoch", value: now())
@@ -124,6 +130,15 @@ def parse(String description) {
 		return createEvent(map)
 	} else
 		return [:]
+}
+
+// Reverses order of bytes in hex string
+def reverseHexString(hexString) {
+	def reversed = ""
+	for (int i = hexString.length(); i > 0; i -= 2) {
+		swaped += hexString.substring(i - 2, i )
+	}
+	return reversed
 }
 
 // Build event map based on type of WXKG02LM button press

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  2016 & 2018 revisions of models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.6b
+ *  Version 0.7b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -16,37 +16,30 @@
  *
  *  Based on SmartThings device handler code by a4refillpad
  *  Reworked for use with Hubitat Elevation hub by gn0st1c with additional code by veeceeoh
- *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, mike.maxwell, rinkek, ronvandegraaf, snalee, tmleafs, twonk, veeceeoh, & xtianpaiva
+ *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, veeceeoh, & xtianpaiva
  *
  *  Notes on capabilities of the different models:
- *  Model WXKG03LM (1 button) - 2016 Revision:
+ *  Model WXKG03LM (1 button) - 2016 Revision (lumi.sensor_86sw1lu):
  *    - Single press results in button 1 "pushed" event
- *  Model WXKG03LM (1 button) - 2018 Revision:
+ *  Model WXKG03LM (1 button) - 2018 Revision (lumi.remote.b186acn01):
  *    - Single press results in button 1 "pushed" event
  *    - Double click results in button 1 "doubleTapped" event
  *    - Hold for longer than 400ms results in button 1 "held" event
- *  Model WXKG02LM (2 button) - 2016 Revision:
+ *  Model WXKG02LM (2 button) - 2016 Revision (lumi.sensor_86sw2Un):
  *    - Single press of left button results in button 1 "pushed" event
  *    - Single press of right button results in button 2 "pushed" event
  *    - Single press of both buttons results in button 3 "pushed" event
- *  Model WXKG02LM (2 button) - 2018 Revision:
- *    - Single press of left button results in button 1 "pushed" event
- *    - Single press of right button results in button 2 "pushed" event
- *    - Single press of both buttons results in button 3 "pushed" event
- *    - Double click of left button results in button 1 "doubleTapped" event
- *    - Double click of right button results in button 2 "doubleTapped" event
- *    - Double click of both buttons results in button 3 "doubleTapped" event
- *    - Hold of left button for longer than 400ms results in button 1 "held" event
- *    - Hold of right button for longer than 400ms results in button 2 "held" event
- *    - Hold of both buttons for longer than 400ms results in button 3 "held" event
+ *  Model WXKG02LM (2 button) - 2018 Revision (lumi.remote.b286acn01):
+ *    - Single press of left/right/both button(s) results in button 1/2/3 "pushed" event
+ *    - Double click of left/right/both button(s) results in button 1/2/3 "doubleTapped" event
+ *    - Hold of left/right/both button(s) for longer than 400ms results in button 1/2/3 "held" event
  *
- *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *  With contributions by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, mike.maxwell, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
  *
- *  https://xiaomi-mi.com/sockets-and-sensors/xiaomi-aqara-smart-light-control-set
  */
 
 metadata {
-	definition (name: "Xiaomi Aqara Wireless Smart Light Switch", namespace: "veeceeoh", author: "gn0st1c") {
+	definition (name: "Aqara Wireless Smart Light Switch", namespace: "veeceeoh", author: "veeceeoh") {
 		capability "Battery"
 		capability "DoubleTapableButton"
 		capability "HoldableButton"
@@ -64,24 +57,27 @@ metadata {
 		attribute "buttonHeldTime", "String"
 
 		// Aqara Wireless Smart Light Switch - one button - model WXKG03LM - 2016 Revision
-		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw1lu"
-		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw1"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw1lu", deviceJoinName: "Aqara 1-button Wireless Light Switch (2016)"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw1", deviceJoinName: "Aqara 1-button Wireless Light Switch (2016)"
 		// Aqara Wireless Smart Light Switch - two button - model WXKG02LM - 2016 Revision
-		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw2Un"
-		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw2"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw2Un", deviceJoinName: "Aqara 2-button Wireless Light Switch (2016)"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.sensor_86sw2", deviceJoinName: "Aqara 2-button Wireless Light Switch (2016)"
 		// Aqara Wireless Smart Light Switch - one button - model WXKG03LM - 2018 Revision
-		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.remote.b186acn01"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.remote.b186acn01", deviceJoinName: "Aqara 1-button Wireless Light Switch (2018)"
 		// Aqara Wireless Smart Light Switch - two button - model WXKG02LM - 2018 Revision
-		fingerprint profileId: "0104", deviceId: "5F01", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.remote.b286acn01"
+		fingerprint profileId: "0104", inClusters: "0000,0003,0019,FFFF,0012", outClusters: "0000,0004,0003,0005,0019,FFFF,0012", manufacturer: "LUMI", model: "lumi.remote.b286acn01", deviceJoinName: "Aqara 2-button Wireless Light Switch (2018)"
 
 		command "resetBatteryReplacedDate"
 	}
 
 	preferences {
 		//Battery Voltage Range
- 		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.9). Default = 2.9 Volts", description: "", type: "decimal", range: "2..2.9"
- 		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.95 to 3.4). Default = 3.05 Volts", description: "", type: "decimal", range: "2.95..3.4"
- 		//Logging Message Config
+		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.9). Default = 2.9 Volts", description: "", type: "decimal", range: "2..2.9"
+		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.95 to 3.4). Default = 3.05 Volts", description: "", type: "decimal", range: "2.95..3.4"
+		//Date/Time Stamp Events Config
+		input name: "lastCheckinEnable", type: "bool", title: "Enable custom date/time stamp events for lastCheckin", description: ""
+		input name: "otherDateTimeEnable", type: "bool", title: "Enable custom date/time stamp events for lastDrop, lastStationary, lastTilt, and lastVibration", description: ""
+		//Logging Message Config
 		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
 		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
 		//Firmware 2.0.5 Compatibility Fix Config
@@ -107,19 +103,20 @@ def parse(String description) {
 	displayDebugLog("Parsing message: ${description}")
 	displayDebugLog("Message payload: ${valueHex}")
 
-	// lastCheckinEpoch is for apps that can use Epoch time/date and lastCheckinTime can be used with Hubitat Dashboard
-	sendEvent(name: "lastCheckinEpoch", value: now())
-	sendEvent(name: "lastCheckinTime", value: new Date().toLocaleString())
-
 	// Send message data to appropriate parsing function based on the type of report
 	if (cluster == "0006") {
-		// Parse Model WXKG02LM button press: endpoint 01 = left, 02 = right, 03 = both
-		map = parse02LMMessage(Integer.parseInt(endpoint))
+		// Parse revision 2016 button messages
+		// Model WXKG03LM: endpoint 1 = button pushed
+		// Model WXKG02LM: endpoint 1 = left button pushed, 2 = right button pushed, 3 = both pushed
+		map = parse16Message(Integer.parseInt(endpoint))
 	} else if (cluster == "0012") {
-		// Parse Model WXKG03LM button message: value 0 = held, 1 = pushed, 2 = double-tapped
-		map = parse03LMMessage(Integer.parseInt(valueHex[2..3],16))
+		// Parse revision 2018 button messages
+		// Model WXKG03LM: endpoint 1 = button pushed
+		// Model WXKG02LM: endpoint 1 = left button pushed, 2 = right button pushed, 3 = both pushed
+		// Both models: valueHex 0 = held, 1 = pushed, 2 = double-tapped
+		map = parse18Message(Integer.parseInt(endpoint, valueHex[2..3],16))
 	} else if (cluster == "0000" & attrId == "0005") {
-		displayDebugLog "Reset button was short-pressed"
+		displayDebugLog "Button was long-pressed"
 		// Parse battery level from longer type of announcement message
 		map = (valueHex.size() > 60) ? parseBattery(valueHex.split('FF42')[1]) : [:]
 	} else if (cluster == "0000" & (attrId == "FF01" || attrId == "FF02")) {
@@ -145,41 +142,45 @@ def reverseHexString(hexString) {
 	return reversed
 }
 
-// Build event map based on type of WXKG02LM button press
-private Map parse02LMMessage(value) {
-	def pushType = ["", "Left", "Right", "Both"]
-	def descText = "${pushType[value]} button${(value == 3) ? "s" : ""} pressed (Button $value pushed)"
+// Build event map based revision 2016 button press
+private Map parse16Message(buttonNum) {
+	def whichButton = [1: ${(state.numOfButtons == 1) ? "Button" : "Left button"}, 2: "Right button", 3: "Both buttons"]
+	def descText = "${whichButton[buttonNum]} was pressed (Button $buttonNum pushed)"
 	displayInfoLog(descText)
 	updateDateTimeStamp("Pressed")
 	return [
 		name: 'pushed',
-		value: value,
+		value: buttonNum,
 		isStateChange: true,
 		descriptionText: descText
 	]
 }
 
-// Build event map based on type of WXKG03LM button press
-private parse03LMMessage(value) {
-	// Button message values (as integer): value 0 = held, 1 = pushed, 2 = double-tapped
+// Build event map based on revision 2018 button press
+private parse18Message(buttonNum, pressType) {
+	// Button press type message values (as integer): value 0 = held, 1 = pushed, 2 = double-tapped
+	def whichButton = [1: ${(state.numOfButtons == 1) ? "Button" : "Left button"}, 2: "Right button", 3: "Both buttons"]
 	def messageType = ["held", "pressed", "double-tapped"]
 	def eventType = ["held", "pushed", "doubleTapped"]
 	def timeStampType = ["Held", "Pressed", "DoubleTapped"]
-	displayInfoLog("Button was ${messageType[value]}")
-	updateDateTimeStamp(timeStampType[value])
+	def descText = "${whichButton[buttonNum]} was ${messageType[pressType]} (Button $buttonNum ${eventType[pressType]})"
+	displayInfoLog(descText)
+	updateDateTimeStamp(timeStampType[pressType])
 	return [
-		name: eventType[value],
-		value: 1,
+		name: eventType[pressType],
+		value: buttonNum,
 		isStateChange: true,
-		descriptionText: "Button was ${messageType[value]}"
+		descriptionText: descText
 	]
 }
 
 // Generate buttonPressedEpoch/Time, buttonHeldEpoch/Time, or buttonReleasedEpoch/Time event for Epoch time/date app or Hubitat dashboard use
 def updateDateTimeStamp(timeStampType) {
-	displayDebugLog("Setting button${timeStampType}Epoch and button${timeStampType}Time to current date/time")
-	sendEvent(name: "button${timeStampType}Epoch", value: now(), descriptionText: "Updated button${timeStampType}Epoch")
-	sendEvent(name: "button${timeStampType}Time", value: new Date().toLocaleString(), descriptionText: "Updated button${timeStampType}Time")
+	if (otherDateTimeEnable) {
+		displayDebugLog("Setting button${timeStampType}Epoch and button${timeStampType}Time to current date/time")
+		sendEvent(name: "button${timeStampType}Epoch", value: now(), descriptionText: "Updated button${timeStampType}Epoch")
+		sendEvent(name: "button${timeStampType}Time", value: new Date().toLocaleString(), descriptionText: "Updated button${timeStampType}Time")
+	}
 }
 
 // Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
@@ -200,18 +201,23 @@ private parseBattery(description) {
 	def roundedPct = Math.min(100, Math.round(pct * 100))
 	def descText = "Battery level is ${roundedPct}% (${rawVolts} Volts)"
 	displayInfoLog(descText)
+	// lastCheckinEpoch is for apps that can use Epoch time/date and lastCheckinTime can be used with Hubitat Dashboard
+	if (lastCheckinEnable) {
+		sendEvent(name: "lastCheckinEpoch", value: now())
+		sendEvent(name: "lastCheckinTime", value: new Date().toLocaleString())
+	}
 	def result = [
 		name: 'battery',
 		value: roundedPct,
 		unit: "%",
-		isStateChange: true,
 		descriptionText: descText
 	]
 	return result
 }
 
 private def displayDebugLog(message) {
-	if (debugLogging) log.debug "${device.displayName}: ${message}"
+	if (debugLogging)
+		log.debug "${device.displayName}: ${message}"
 }
 
 private def displayInfoLog(message) {
@@ -221,15 +227,9 @@ private def displayInfoLog(message) {
 
 //Reset the batteryLastReplaced date to current date
 def resetBatteryReplacedDate(paired) {
-	def newlyPaired = paired ? " for newly paired sensor" : ""
-	sendEvent(name: "batteryLastReplaced", value: new Date())
+	def newlyPaired = paired ? " for newly paired device" : ""
+	sendEvent(name: "batteryLastReplaced", value: new Date().format("MMM dd yyyy", location.timeZone))
 	displayInfoLog("Setting Battery Last Replaced to current date${newlyPaired}")
-}
-
-// this call is here to avoid Groovy errors when the Push command is used
-// it is empty because the Xioami button is non-controllable
-def push() {
-	displayDebugLog("No action taken on Push Command. This button cannot be controlled.")
 }
 
 // installed() runs just after a sensor is paired

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -33,7 +33,7 @@
  */
 
 metadata {
-	definition (name: "Xiaomi Aqara Dual Button Light Switch", namespace: "veeceeoh", author: "gn0st1c") {
+	definition (name: "Xiaomi Aqara Wireless Smart Light Switch", namespace: "veeceeoh", author: "gn0st1c") {
 		capability "Battery"
 		capability "DoubleTapableButton"
 		capability "HoldableButton"
@@ -80,7 +80,7 @@ def parse(String description) {
 
 	// lastCheckin can be used with webCoRE
 	sendEvent(name: "lastCheckin", value: now())
-	sendEvent(name: "lastCheckinTime", value: formatDate())
+	sendEvent(name: "lastCheckinTime", value: formatDate()
 
 	displayDebugLog("Parsing message: ${description}")
 
@@ -91,6 +91,7 @@ def parse(String description) {
 	} else if (cluster == "0012") {
 		// Parse Model WXKG03LM button message: value 0 = push, 1 = double-click, 2 = hold
 		map = parse03LMMessage(Integer.parseInt(valueHex[2..3],16))
+		}
 	} else if (cluster == "0000" & attrId == "0005") {
 		displayDebugLog "Reset button was short-pressed"
 		// Parse battery level from longer type of announcement message

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  2016 & 2018 revisions of models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7.5b
+ *  Version 0.8
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
+++ b/devicedrivers/xiaomi-aqara-wireless-switch.src/xiaomi-aqara-wireless-switch.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Wireless Smart Light Switch
  *  2016 & 2018 revisions of models WXKG03LM (1 button) and WXKG02LM (2 buttons)
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7.1b
+ *  Version 0.7.2b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -88,7 +88,7 @@ metadata {
 // Parse incoming device messages to generate events
 def parse(String description) {
 	def endpoint = description.split(",").find {it.split(":")[0].trim() == "endpoint"}?.split(":")[1].trim()
-	def cluster	= description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def encoding = Integer.parseInt(description.split(",").find {it.split(":")[0].trim() == "encoding"}?.split(":")[1].trim(), 16)
 	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
@@ -144,7 +144,7 @@ def reverseHexString(hexString) {
 
 // Build event map based revision 2016 button press
 private Map parse16Message(buttonNum) {
-	def whichButton = [1: ${(state.numOfButtons == 1) ? "Button" : "Left button"}, 2: "Right button", 3: "Both buttons"]
+	def whichButton = [1: (state.numOfButtons == 1) ? "Button" : "Left button", 2: "Right button", 3: "Both buttons"]
 	def descText = "${whichButton[buttonNum]} was pressed (Button $buttonNum pushed)"
 	displayInfoLog(descText)
 	updateDateTimeStamp("Pressed")
@@ -158,7 +158,7 @@ private Map parse16Message(buttonNum) {
 
 // Build event map based on revision 2018 button press
 private parse18Message(buttonNum, pressType) {
-	def whichButton = [1: ${(state.numOfButtons == 1) ? "Button" : "Left button"}, 2: "Right button", 3: "Both buttons"]
+	def whichButton = [1: (state.numOfButtons == 1) ? "Button" : "Left button", 2: "Right button", 3: "Both buttons"]
 	def messageType = ["held", "pressed", "double-tapped"]
 	def eventType = ["held", "pushed", "doubleTapped"]
 	def timeStampType = ["Held", "Pressed", "DoubleTapped"]


### PR DESCRIPTION
This is a NEW Hubitat device driver to use with both the 1 button and 2 button Aqara Wireless Smart Light Switch devices (models WXKG03LM and WXKG02LM, respectively). It is based on the previous Aqara Smart Light Switch - 2 button model WXKG03LM device driver, with the following changes:

* Added parsing of button press, double-tap, and hold messages sent by model WXKG03LM (1 button) which are posted as Hubitat button 1 `pushed`, `doubleTapped`, and `held`, respectively
* Changed the initial set up for the numberOfButtons = 3 event to happen only once, but if the device handler is used with model WXKG03LM, on the first button message received a numberOfButtons = 1 event will be posted
* Added attributes `buttonDoubleTapped` and `buttonHeld` to contain the most recent Epoch Time date/time stamps of corresponding button events that can be used in addition to `buttonPressed` in WebCoRE.
* Added attributes `buttonPressedTime`, `buttonDoubleTappedTime`, and `buttonHeldTime` which contain the most recent date/time stamps (in human-readble form) of corresponding button events that can be used with the Hubitat Dashboard.
* Added fingerprint lines for model WXKG03LM