### PR TITLE
[BETA] Aqara Vibration Sensor Device Driver v0.7.2b (Ready to test)

### DIFF
--- a/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
@@ -1,8 +1,7 @@
 /**
- *  Xiaomi Aqara Vibration Sensor
- *  Model DJT11LM
+ *  Xiaomi Aqara Vibration Sensor - model DJT11LM
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7.2b
+ *  Version 0.7.3b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -79,6 +78,8 @@ metadata {
 		//Logging Message Config
 		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
 		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
+		//Firmware 2.0.5 Compatibility Fix Config
+		input name: "oldFirmware", type: "bool", title: "DISABLE 2.0.5 firmware compatibility fix (for users of 2.0.4 or earlier)", description: ""
 	}
 }
 
@@ -91,6 +92,10 @@ def parse(String description) {
 	def eventType
 	Map map = [:]
 	def cmds = []
+
+	if (!oldFirmware & valueHex)
+		// Reverse order of bytes in description's value hex string - required for Hubitat firmware 2.0.5 or newer
+		valueHex = reverseHexString(valueHex)
 
 	// lastCheckinEpoch is for apps that can use Epoch time/date and lastCheckinTime can be used with Hubitat Dashboard
 	if (lastCheckinEnable) {
@@ -133,6 +138,15 @@ def parse(String description) {
 		return cmds
 	} else
 		return [:]
+}
+
+// Reverses order of bytes in hex string
+def reverseHexString(hexString) {
+	def reversed = ""
+	for (int i = hexString.length(); i > 0; i -= 2) {
+		swaped += hexString.substring(i - 2, i )
+	}
+	return reversed
 }
 
 // Convert XYZ Accelerometer values to 3-Axis angle position

--- a/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Vibration Sensor
  *  Model DJT11LM
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7b
+ *  Version 0.7.1b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
@@ -2,7 +2,7 @@
  *  Xiaomi Aqara Vibration Sensor
  *  Model DJT11LM
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7.1b
+ *  Version 0.7.2b
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -140,9 +140,9 @@ private Map convertAccelValues(value) {
 	short x = (short)Integer.parseInt(value[8..11],16)
 	short y = (short)Integer.parseInt(value[4..7],16)
 	short z = (short)Integer.parseInt(value[0..3],16)
-	float Psi = Math.round(Math.atan(x/Math.sqrt(z*z+y*y))*1800/Math.PI)/10
-	float Phi = Math.round(Math.atan(y/Math.sqrt(x*x+z*z))*1800/Math.PI)/10
-	float Theta = Math.round(Math.atan(z/Math.sqrt(x*x+y*y))*1800/Math.PI)/10
+	def Psi = Math.round(Math.atan(x/Math.sqrt(z*z+y*y))*1800/Math.PI)/10
+	def Phi = Math.round(Math.atan(y/Math.sqrt(x*x+z*z))*1800/Math.PI)/10
+	def Theta = Math.round(Math.atan(z/Math.sqrt(x*x+y*y))*1800/Math.PI)/10
 	def descText = "Calculated angles are Psi = ${Psi}°, Phi = ${Phi}°, Theta = ${Theta}° "
 	displayDebugLog("Raw accelerometer XYZ axis values = $x, $y, $z")
 	displayDebugLog(descText)
@@ -152,14 +152,14 @@ private Map convertAccelValues(value) {
 	if (!state.closedX || !state.openX)
 		displayInfoLog("Open/Closed position is unknown because Open and/or Closed positions have not been set")
 	else {
-		def float cX = Float.parseFloat(state.closedX)
-		def float cY = Float.parseFloat(state.closedY)
-		def float cZ = Float.parseFloat(state.closedZ)
-		def float oX = Float.parseFloat(state.openX)
-		def float oY = Float.parseFloat(state.openY)
-		def float oZ = Float.parseFloat(state.openZ)
+		def cX = state.closedX
+		def cY = state.closedY
+		def cZ = state.closedZ
+		def oX = state.openX
+		def oY = state.openY
+		def oZ = state.openZ
 		// the margin of error value is used to increase/decrease the area of possible positions considered as open / closed
-		def float e = (marginOfError) ? marginOfError : 10.0
+		def e = (marginOfError) ? marginOfError : 10.0
 		def ocPosition = "unknown"
 		if ((Psi < cX + e) && (Psi > cX - e) && (Phi < cY + e) && (Phi > cY - e) && (Theta < cZ + e) && (Theta > cZ - e))
 			ocPosition = "closed"

--- a/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
@@ -16,7 +16,7 @@
  *
  *  Based on SmartThings device handler code by a4refillpad
  *  Reworked for use with Hubitat Elevation hub by veeceeoh
- *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, oltman, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, mike.maxwell, oltman, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
  *
  *  Known issues:
  *  + Xiaomi devices send reports based on changes, and a status report every 50-60 minutes. These settings cannot be adjusted.

--- a/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
@@ -1,0 +1,414 @@
+/**
+ *  Xiaomi Aqara Vibration Sensor
+ *  Model DJT11LM
+ *  Device Driver for Hubitat Elevation hub
+ *  Version 0.5b
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  Based on SmartThings device handler code by a4refillpad
+ *  Reworked for use with Hubitat Elevation hub by veeceeoh
+ *  Additional contributions to code by alecm, alixjg, bspranger, gn0st1c, foz333, jmagnuson, oltman, rinkek, ronvandegraaf, snalee, tmleafs, twonk, & veeceeoh
+ *
+ *  Known issues:
+ *  + Xiaomi devices send reports based on changes, and a status report every 50-60 minutes. These settings cannot be adjusted.
+ *  + The battery level / voltage is not reported at pairing. Wait for the first status report, 50-60 minutes after pairing.
+ *    However, the Aqara Door/Window sensor battery level can be retrieved immediately with a short-press of the reset button.
+ *  + Pairing Xiaomi devices can be difficult as they were not designed to use with a Hubitat hub.
+ *    Holding the sensor's reset button until the LED blinks will start pairing mode.
+ *    3 quick flashes indicates success, while one long flash means pairing has not started yet.
+ *    In either case, keep the sensor "awake" by short-pressing the reset button repeatedly, until recognized by Hubitat.
+ *  + The connection can be dropped without warning. To reconnect, put Hubitat in "Discover Devices" mode, and follow
+ *    the same steps for pairing. As long as it has not been removed from the Hubitat's device list, when the LED
+ *    flashes 3 times, the Aqara Motion Sensor should be reconnected and will resume reporting as normal
+ */
+
+metadata {
+	definition (name: "Xiaomi Aqara Vibration Sensor", namespace: "veeceeoh", author: "veeceeoh") {
+		capability "Acceleration Sensor"
+		capability "Battery"
+		capability "Configuration"
+		capability "Contact Sensor"
+		capability "Motion Sensor"
+		capability "PushableButton"
+		capability "Refresh"
+		capability "Sensor"
+		capability "Three Axis"
+
+		attribute "activityLevel", "String"
+		attribute "angleX", "number"
+		attribute "angleY", "number"
+		attribute "angleZ", "number"
+		attribute "batteryRuntime", "String"
+		attribute "lastCheckin", "String"
+		attribute "lastCheckinTime", "Date"
+		attribute "lastDrop", "String"
+		attribute "lastDropTime", "Date"
+		attribute "lastStationary", "String"
+		attribute "lastStationaryTime", "Date"
+		attribute "lastTilt", "String"
+		attribute "lastTiltTime", "Date"
+		attribute "lastVibration", "String"
+		attribute "lastVibrationTime", "Date"
+		attribute "sensitivityLevel", "String"
+		attribute "sensorStatus", "enum", ["vibrating", "tilted", "dropped", "Stationary"]
+		attribute "tiltAngle", "String"
+
+		fingerprint profileId: "0104", deviceId: "000A", inClusters: "0000,0003,0019,0101", outClusters: "0000,0004,0003,0005,0019,0101", manufacturer: "LUMI", model: "lumi.vibration.aq1"
+
+		command "resetBatteryRuntime"
+		command "changeSensitivity"
+		command "setOpenPosition"
+		command "setClosedPosition"
+	}
+
+	preferences {
+		//Reset to No Motion Config
+		input "motionreset", "number", title: "", description: "Number of seconds to reset Motion = Active when sensor detects vibration/shock (default = 65)", range: "1..7200"
+		//Battery Voltage Range
+		input name: "voltsmin", title: "Min Volts (0% battery = ___ volts, range 2.0 to 2.9). Default = 2.9 Volts", description: "", type: "decimal", range: "2..2.9"
+		input name: "voltsmax", title: "Max Volts (100% battery = ___ volts, range 2.95 to 3.4). Default = 3.05 Volts", description: "", type: "decimal", range: "2.95..3.4"
+		//Logging Message Config
+		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
+		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
+	}
+}
+
+// Parse incoming device messages to generate events
+def parse(String description) {
+    displayDebugLog "Parsing sensor message: ${description}"
+	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
+	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
+	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+	def eventType
+	Map map = [:]
+
+	// lastCheckin can be used with webCoRE and lastCheckinTime used with Hubitat Dashboard
+	sendEvent(name: "lastCheckin", value: now())
+	sendEvent(name: "lastCheckinTime", value: new Date().toLocaleString())
+
+	// Send message data to appropriate parsing function based on the type of report
+	if (attrId == "0055") {
+	// Handles vibration (value 01), tilt (value 02), and drop (value 03) event messages
+		if (value?.endsWith('0002')) {
+			eventType = 2
+			parseTiltAngle(value[0..3])
+		} else {
+			eventType = Integer.parseInt(value,16)
+		}
+		map = mapSensorEvent(eventType)
+	} else if (attrId == "0508") {
+		// Handles XYZ Accelerometer values
+		map = convertAccelValues(value)
+	} else if (attrId == "0505") {
+		map = mapActivityLevel(value)
+	} else if (cluster == "0000" & attrId == "0005") {
+		displayDebugLog "Reset button was short-pressed"
+		// Parse battery level from longer type of announcement message
+		map = (value.size() > 60) ? parseBattery(value.split('FF42')[1]) : [:]
+	} else if (cluster == "0000" & (attrId == "FF01" || attrId == "FF02")) {
+		// Parse battery level from hourly announcement message
+		map = (value.size() > 30) ? parseBattery(value) : [:]
+	} else if (!(cluster == "0000" & attrId == "0001")) {
+		displayDebugLog "Unable to parse ${description}"
+	}
+
+	if (map != [:]) {
+		displayDebugLog("Creating event $map")
+		return createEvent(map)
+	} else
+		return [:]
+}
+
+// Convert XYZ Accelerometer values to 3-Axis angle position
+private Map convertAccelValues(value) {
+	short x = (short)Integer.parseInt(value[8..11],16)
+	short y = (short)Integer.parseInt(value[4..7],16)
+	short z = (short)Integer.parseInt(value[0..3],16)
+	float Psi = Math.round(Math.atan(x/Math.sqrt(z*z+y*y))*1800/Math.PI)/10
+	float Phi = Math.round(Math.atan(y/Math.sqrt(x*x+z*z))*1800/Math.PI)/10
+	float Theta = Math.round(Math.atan(z/Math.sqrt(x*x+y*y))*1800/Math.PI)/10
+	def descText = ": Calculated angles are Psi = ${Psi}°, Phi = ${Phi}°, Theta = ${Theta}° "
+	displayDebugLog(": Raw accelerometer XYZ axis values = $x, $y, $z")
+	displayDebugLog(descText)
+	sendEvent(name: "angleX", value: Psi, displayed: false)
+	sendEvent(name: "angleY", value: Phi, displayed: false)
+	sendEvent(name: "angleZ", value: Theta, displayed: false)
+	if (!state.closedX || !state.openX)
+		displayInfoLog(": Open/Closed position is unknown because Open and/or Closed positions have not been set")
+	else {
+		def float cX = Float.parseFloat(state.closedX)
+		def float cY = Float.parseFloat(state.closedY)
+		def float cZ = Float.parseFloat(state.closedZ)
+		def float oX = Float.parseFloat(state.openX)
+		def float oY = Float.parseFloat(state.openY)
+		def float oZ = Float.parseFloat(state.openZ)
+		def float e = 10.0 // Sets range for margin of error
+		def ocPosition = "unknown"
+		if ((Psi < cX + e) && (Psi > cX - e) && (Phi < cY + e) && (Phi > cY - e) && (Theta < cZ + e) && (Theta > cZ - e))
+			ocPosition = "closed"
+		else if ((Psi < oX + e) && (Psi > oX - e) && (Phi < oY + e) && (Phi > oY - e) && (Theta < oZ + e) && (Theta > oZ - e))
+			ocPosition = "open"
+		else
+			displayDebugLog(": The current calculated angle position does not match either stored open/closed positions")
+		sendpositionEvent(ocPosition)
+	}
+	return [
+		name: 'threeAxis',
+		value: [Psi, Phi, Theta],
+		linkText: getLinkText(device),
+		isStateChange: true,
+		descriptionText: descText,
+	]
+}
+
+// Handles Recent Activity level value messages
+private Map mapActivityLevel(value) {
+	def level = Integer.parseInt(value[0..3],16)
+	def descText = ": Recent activity level reported at $level"
+	displayInfoLog(descText)
+	return [
+		name: 'activityLevel',
+		value: level,
+		descriptionText: "$device.displayName$descText",
+	]
+}
+
+// Create map of values to be used for vibration, tilt, or drop event
+private Map mapSensorEvent(value) {
+	def seconds = (value == 1 || value == 4) ? (motionreset ? motionreset : 65) : 2
+	def time = new Date(now() + (seconds * 1000))
+	def statusType = ["Stationary", "Vibration", "Tilt", "Drop", "", ""]
+	def eventName = ["", "motion", "acceleration", "button", "motion", "acceleration"]
+	def eventType = ["", "active", "active", "pushed", "inactive", "inactive"]
+	def eventMessage = [" is stationary", " was vibrating or moving (Motion active)", " was tilted (Acceleration active)", " was dropped (Button pushed)", ": Motion reset to inactive after $seconds seconds", ": Acceleration reset to inactive"]
+	if (value < 4) {
+		sendEvent(name: "sensorStatus", value: statusType[value], descriptionText: "$device.displayName${eventMessage[value]}", isStateChange: true, displayed: (value == 0) ? true : false)
+		updateDateTimeStamp(statusType[value])
+	}
+	displayInfoLog("${eventMessage[value]}")
+	if (value == 0)
+		return
+	else if (value == 1) {
+		runOnce(time, clearmotionEvent)
+		state.motionactive = 1
+	}
+	else if (value == 2)
+		runOnce(time, clearaccelEvent)
+	else if (value == 3)
+		runOnce(time, cleardropEvent)
+	return [
+		name: eventName[value],
+		value: eventType[value],
+		descriptionText: "$device.displayName${eventMessage[value]}",
+		isStateChange: true,
+		displayed: true
+	]
+}
+
+// Handles tilt angle change message and posts event to update UI tile display
+private parseTiltAngle(value) {
+	def angle = Integer.parseInt(value,16)
+	def descText = ": tilt angle changed by $angle°"
+	sendEvent(
+		name: 'tiltAngle',
+		value: angle,
+		descriptionText : "$device.displayName$descText",
+		isStateChange:true,
+		displayed: true
+	)
+	displayInfoLog(descText)
+}
+
+// Convert raw 4 digit integer voltage value into percentage based on minVolts/maxVolts range
+private parseBattery(description) {
+	displayDebugLog("Battery parse string = ${description}")
+	def MsgLength = description.size()
+	def rawValue
+	for (int i = 4; i < (MsgLength-3); i+=2) {
+		if (description[i..(i+1)] == "21") { // Search for byte preceeding battery voltage bytes
+			rawValue = Integer.parseInt((description[(i+4)..(i+5)] + description[(i+2)..(i+3)]),16)
+			break
+		}
+	}
+	def rawVolts = rawValue / 1000
+	def minVolts = voltsmin ? voltsmin : 2.9
+	def maxVolts = voltsmax ? voltsmax : 3.05
+	def pct = (rawVolts - minVolts) / (maxVolts - minVolts)
+	def roundedPct = Math.min(100, Math.round(pct * 100))
+	def descText = "Battery level is ${roundedPct}% (${rawVolts} Volts)"
+	displayInfoLog(descText)
+	return [
+		name: 'battery',
+		value: roundedPct,
+		unit: "%",
+		isStateChange: true,
+		descriptionText: descText
+	]
+}
+
+//Reset the batteryLastReplaced date to current date
+def resetBatteryReplacedDate(paired) {
+	def newlyPaired = paired ? " for newly paired sensor" : ""
+	sendEvent(name: "batteryLastReplaced", value: new Date())
+	displayInfoLog("Setting Battery Last Replaced to current date${newlyPaired}")
+}
+
+// installed() runs just after a sensor is paired using the "Add a Thing" method in the SmartThings mobile app
+def installed() {
+	state.prefsSetCount = 0
+	displayInfoLog(": Installing")
+	init(0)
+}
+
+// configure() runs after installed() when a sensor is paired
+def configure() {
+	displayInfoLog(": Configuring")
+	mapSensorEvent(0)
+	refresh()
+	init()
+	state.prefsSetCount = 1
+	return
+}
+
+// updated() will run twice every time user presses save in preference settings page
+def updated() {
+	def cmd
+	displayInfoLog(": Updating preference settings")
+	init()
+	cmd = refresh()
+	displayInfoLog(": Info message logging enabled")
+	displayDebugLog(": Debug message logging enabled")
+	return cmd
+}
+
+def init() {
+	if (!device.currentState('batteryLastReplaced')?.value)
+		resetBatteryReplacedDate(true)
+	sendEvent(name: "numberOfButtons", value: 1, displayed: false)
+}
+
+// update lastStationary, lastVibration, lastTilt, or lastDrop to current date/time
+def updateDateTimeStamp(timeStampType) {
+	displayDebugLog("Setting last${timeStampType} & last${timeStampType}Time to current date/time for webCoRE/dashboard use")
+	sendEvent(name: "last${timeStampType}", value: now(), descriptionText: "Updated button${timeStampType} (webCoRE)")
+	sendEvent(name: "last${timeStampType}Time", value: new Date().toLocaleString(), descriptionText: "Updated button${timeStampType}Time")
+}
+
+def clearmotionEvent() {
+	def result = [:]
+	if (device.currentState('sensorStatus')?.value == "Vibration")
+		mapSensorEvent(0)
+	result = mapSensorEvent(4)
+	state.motionactive = 0
+	displayDebugLog(": Sending event $result")
+	sendEvent(result)
+}
+
+def clearaccelEvent() {
+	def result = [:]
+	if (device.currentState('sensorStatus')?.value == "Tilt") {
+		if (state.motionactive == 1)
+			sendEvent(name: "sensorStatus", value: "Vibration", displayed: false)
+		else
+			mapSensorEvent(0)
+	}
+	result = mapSensorEvent(5)
+	displayDebugLog(": Sending event $result")
+	sendEvent(result)
+}
+
+def cleardropEvent() {
+	if (device.currentState('sensorStatus')?.value == "Drop") {
+		if (state.motionactive == 1)
+			sendEvent(name: "sensorStatus", value: "Vibration", displayed: false)
+		else
+			mapSensorEvent(0)
+	}
+}
+
+def setClosedPosition() {
+	if (device.currentValue('angleX')) {
+		state.closedX = device.currentState('angleX').value
+		state.closedY = device.currentState('angleY').value
+		state.closedZ = device.currentState('angleZ').value
+		sendpositionEvent("closed")
+		displayInfoLog(": Closed position successfully set")
+		displayDebugLog(": Closed position set to $state.closedX°, $state.closedY°, $state.closedZ°")
+	}
+	else
+		displayDebugLog(": Closed position NOT set because no 3-axis accelerometer reports have been received yet")
+}
+
+def setOpenPosition() {
+	if (device.currentValue('angleX')) {
+		state.openX = device.currentState('angleX').value
+		state.openY = device.currentState('angleY').value
+		state.openZ = device.currentState('angleZ').value
+		sendpositionEvent("open")
+		displayInfoLog(": Open position successfully set")
+		displayDebugLog(": Open position set to $state.openX°, $state.openY°, $state.openZ°")
+	}
+	else
+		displayDebugLog(": Open position NOT set because no 3-axis accelerometer reports have been received yet")
+}
+
+def sendpositionEvent(String ocPosition) {
+	def descText = ": Calculated position is $ocPosition"
+	displayInfoLog(descText)
+	sendEvent(
+		name: "contact",
+		value: ocPosition,
+		isStateChange: true,
+		descriptionText: "$device.displayName$descText")
+}
+
+def changeSensitivity() {
+	state.sensitivity = (state.sensitivity < 3) ? state.sensitivity + 1 : 1
+	def attrValue = [0x00, 0x15, 0x0B, 0x00]
+	def levelText = ["", "Low", "Medium", "High"]
+	def descText = ": Sensitivity level set to ${levelText[state.sensitivity]}"
+	def cmd = [
+        "zigbee.writeAttribute(0x0000, 0xFF0D, 0x20, ${attrValue[state.sensitivity]}, [mfgCode: 0x115F])",
+        "he cmd 0x${device.deviceNetworkId} 0x${device.endpointId} 0x0000 0xFF0D {${attrValue[state.sensitivity]}}",
+		"he rattr 0x${device.deviceNetworkId} 0x${device.endpointId} 0x0000 0xFF0D"
+	]
+	sendHubCommand(new hubitat.device.HubAction("zigbee.writeAttribute(0x0000, 0xFF0D, 0x20, ${attrValue[state.sensitivity]}, [mfgCode: 0x115F])"))
+	sendHubCommand(new hubitat.device.HubAction("zigbee.readAttribute(0x0000, 0xFF0D, [mfgCode: 0x115F])"))
+//	zigbee.writeAttribute(0x0000, 0xFF0D, 0x20, attrValue[state.sensitivity], [mfgCode: 0x115F])
+//	zigbee.readAttribute(0x0000, 0xFF0D, [mfgCode: 0x115F])
+	sendEvent(name: "sensitivityLevel", value: levelText[state.sensitivity], isStateChange: true, descriptionText: descText)
+	displayInfoLog(descText)
+	return cmd
+}
+
+private def displayDebugLog(message) {
+	if (debugLogging) log.debug "${device.displayName}: ${message}"
+}
+
+private def displayInfoLog(message) {
+	if (infoLogging || state.prefsSetCount != 1)
+		log.info "${device.displayName}: ${message}"
+}
+
+def refresh() {
+	def cmd
+    displayInfoLog(": Refreshing UI display")
+	if (!state.sensitivity) {
+		state.sensitivity = 0
+		cmd = changeSensitivity()
+	}
+	if (device.currentValue('tiltAngle') == null)
+		sendEvent(name: 'tiltAngle', value: "--", isStateChange: true, displayed: false)
+	if (device.currentValue('activityLevel') == null)
+		sendEvent(name: 'activityLevel', value: "--", isStateChange: true, displayed: false)
+	return cmd
+}

--- a/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-aqara-vibration-sensor-hubitat.src/xiaomi-aqara-vibration-sensor-hubitat.groovy
@@ -88,7 +88,7 @@ def parse(String description) {
 	displayDebugLog "Parsing sensor message: ${description}"
 	def cluster = description.split(",").find {it.split(":")[0].trim() == "cluster"}?.split(":")[1].trim()
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
-	def value = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
+	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
 	def eventType
 	Map map = [:]
 	def cmds = []
@@ -106,16 +106,16 @@ def parse(String description) {
 	// Send message data to appropriate parsing function based on the type of report
 	if (attrId == "0055") {
 	// Handles vibration (value 01), tilt (value 02), and drop (value 03) event messages
-		if (value?.endsWith('0002')) {
+		if (valueHex?.endsWith('0002')) {
 			eventType = 2
-			parseTiltAngle(value[0..3])
+			parseTiltAngle(valueHex[0..3])
 		} else {
-			eventType = Integer.parseInt(value,16)
+			eventType = Integer.parseInt(valueHex,16)
 		}
 		map = mapSensorEvent(eventType)
 	} else if (attrId == "0508") {
 		// Handles XYZ Accelerometer values to determine position
-		convertAccelValues(value)
+		convertAccelValues(valueHex)
 	} else if (attrId == "0505") {
 		// Handles recent activity level value reports
 		map = mapActivityLevel(value)
@@ -125,7 +125,7 @@ def parse(String description) {
 		cmds = changeSensitivity()
 	} else if (cluster == "0000" & (attrId == "FF01" || attrId == "FF02")) {
 		// Parse battery level from hourly announcement message
-		map = (value.size() > 30) ? parseBattery(value) : [:]
+		map = (valueHex.size() > 30) ? parseBattery(valueHex) : [:]
 	} else if (!(cluster == "0000" & attrId == "0001")) {
 		displayDebugLog "Unable to parse ${description}"
 	}

--- a/devicedrivers/xiaomi-motion-sensor-hubitat.src/xiaomi-motion-sensor-hubitat.groovy
+++ b/devicedrivers/xiaomi-motion-sensor-hubitat.src/xiaomi-motion-sensor-hubitat.groovy
@@ -1,7 +1,7 @@
 /**
- *  Xiaomi "Original" Motion Sensor
+ *  Xiaomi "Original" Motion Sensor - model RTCGQ01LM
  *  Device Driver for Hubitat Elevation hub
- *  Version 0.7
+ *  Version 0.7.1
  *
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -56,6 +56,8 @@ metadata {
  		//Logging Message Config
  		input name: "infoLogging", type: "bool", title: "Enable info message logging", description: ""
  		input name: "debugLogging", type: "bool", title: "Enable debug message logging", description: ""
+		//Firmware 2.0.5 Compatibility Fix Config
+		input name: "oldFirmware", type: "bool", title: "DISABLE 2.0.5 firmware compatibility fix (for users of 2.0.4 or earlier)", description: ""
 	}
 }
 
@@ -65,6 +67,10 @@ def parse(String description) {
 	def attrId = description.split(",").find {it.split(":")[0].trim() == "attrId"}?.split(":")[1].trim()
 	def valueHex = description.split(",").find {it.split(":")[0].trim() == "value"}?.split(":")[1].trim()
 	Map map = [:]
+
+	if (!oldFirmware & valueHex)
+		// Reverse order of bytes in description's value hex string - required for Hubitat firmware 2.0.5 or newer
+		valueHex = reverseHexString(valueHex)
 
 	// lastCheckin can be used with webCoRE
 	sendEvent(name: "lastCheckin", value: now())
@@ -89,6 +95,15 @@ def parse(String description) {
 		return createEvent(map)
 	} else
 		return [:]
+}
+
+// Reverses order of bytes in hex string
+def reverseHexString(hexString) {
+	def reversed = ""
+	for (int i = hexString.length(); i > 0; i -= 2) {
+		swaped += hexString.substring(i - 2, i )
+	}
+	return reversed
 }
 
 // Parse motion active report


### PR DESCRIPTION
**Initial beta release of Hubitat Device Driver**

|Sensor Function|Hubitat event|Notes
|---|---|---|
|Vibration/Shock Detected|`motion = active`|`motion inactive` is timer-based |
|Tilt Detected | `acceleration = active` | `acceleration inactive` is timer-based |
|Tilt Angle | `tiltAngle =` _value_ | Custom attribute _(see notes below)_|
|Drop Detected|`button 1 = pushed`| |
|XYZ accelerometer values | `contact = open/closed` | _see notes below_ |
|Activity Report values | Custom attribute |_see notes below_ |
|Change sensitivity level | n/a |_see notes below_ |

**Notes**:
* _Sensor Status:_ Purely for use in a Hubitat Dashboard, the custom attribute `sensorStatus` can be used for displaying the following states: `Stationary`, `Vibration`, `Tilt`, and `Drop`. The `Open` / `Close` states are not displayed because they can occur simultaneously during a vibration detected (`motion = active`) state.

* _Vibration/Shock detection:_ The sensor does _not_ seem to work well for clothes washer / dryer cycle detection, and also no message is sent when the sensor is stationary. If "heavy" enough vibration continues, the sensor only sends subsequent vibration/shock detected messages _every 60 seconds_, so the device driver will is set up to reset `motion` to `inactive` after 65 seconds as a default, with a user-adjustable reset time in the preference section of the device details page (see screenshot below).

* _Tilt detection:_ The sensor sends a tilt detected message when it has been rotated in any direction, and both a Tilt Angle value message and XYZ accelerometer values message are sent when the sensor stops moving and has come to a resting position. Because Tilt detected is assigned to the `acceleration` capability, it also resets to `acceleration inactive` using a timer - in this case, 2 seconds, not user-adjustable. The reason for 2-seconds is purely to give a visual indicator in a Hubitat Dashboard if the custom attribute `sensorStatus` is used. However, since `acceleration` is state-based, it needs to be reset to `inactive` when no more tilts are detected after some length of time.

* _Tilt Angle_: This value is sent after the sensor has been rotated and come to a resting position. It is a _relative_ value, so in other words, the difference in angle from the sensor's previous resting position. There doesn't seem to be any built-in Hubitat capability that is well suited to assign to this data, so it is assigned to the custom attribute `tiltAngle` for events that can be used in WebCoRE, by a custom App, or displayed in a Hubitat Dashboard. It is not useful for determining an absolute open or closed position, however, which is why the XYZ Accelerometer value message data is used for that purpose.

* _Drop detection_: The sensor sends this message whenever a free-fall drop is detected. It seemed best assigned to a trigger action, so `button 1 pushed` is used.

* _XYZ Accelerometer values_: These values are sent after the sensor has been rotated and come to a resting position. Unlike the Tilt Angle report, they are _absolute_ values, and in the device driver are converted to a 3-axis angle position. Although this calculated position is not extremely accurate, it is consistent enough to use for setting and storing absolute open and close positions. This is accomplished by putting the sensor in each position and then pressing the "Set Open" or "Set Closed" buttons in the device view page while logged into the Hubitat Hub (see screenshot below). The conversion to 3-axis positions includes a "margin of error" to allow for positions that don't exactly match the stored user-set position. I may make this margin value available for users to change in the device preferences.

* _Change Sensitivity Level_: The sensor has 3 hardware sensitivity levels: low, medium, and high. Changing the level requires pushing the "Change Sensitivity Level" button in the device view page (see screenshot below). However, because no "level changed successfully" message from the sensor is passed on by the Hubitat hub (or in SmartThings, for that matter) and the current level cannot be queried by the Hubitat driver, I have not yet been able to confirm that the level change command works correctly. So I can't currently guarantee it will work on the Hubitat platform. I plan on opening a new forum thread to ask about the best method for sending the ZigBee write attribute command in this case.

An example screenshot from the device details page of my Aqara Vibration Sensor using the beta device driver:
![screen shot 2018-11-13 at 9 24 26 pm](https://user-images.githubusercontent.com/33558908/48464647-10a21080-e795-11e8-8758-0c8424d11dcf.PNG)
