### PR TITLE
[BETA] Xiaomi Mijia Honeywell Fire Detector device driver v0.6b

### DIFF
--- a/devicedrivers/xiaomi-honeywell-smoke-detector.src/xiaomi-honeywell-smoke-detector.groovy
+++ b/devicedrivers/xiaomi-honeywell-smoke-detector.src/xiaomi-honeywell-smoke-detector.groovy
@@ -110,7 +110,8 @@ def parse(String description) {
 				displayDebugLog("Unable to parse read attribute message")
 			}
 		}
-		displayInfoLog(map.descriptionText)
+		if (result.descriptionText)
+			displayInfoLog(result.descriptionText)
 	}
 	if (result) {
 		displayDebugLog("Creating event $result")


### PR DESCRIPTION
[BETA] v0.6b Ready to test

Changelist
* Reworked and refactored message parse code to (hopefully) eliminate errors introduced in driver v0.5.1
* Corrected an undefined object used when parsing IAS Enroll Request messages
* Fixed debug message output behavior so that "Enable debug message logging" now controls all debug message log output
* Renamed custom attributes `lastCheckin`, `lastClear`, `lastDetected`, and `lastTested` to `lastCheckinEpoch`, `lastClearEpoch`, `lastDetectedEpoch`, and `lastTestedEpoch`, respectively, used to generate Epoch time/date stamp events
* Removed any references to WebCoRE for use of Epoch-time/date stamp custom attribute events and replaced with "Apps that can use Epoch time/date stamps"
* Added `lastCheckinTime`, `lastClearTime`, `lastDetectedTime`, and `lastTestedTime` custom attributes, to be used to generate human readable time/date stamp events
* Changed lastCheckin____ events to only occur when the sensor checks in (at same time as when battery voltage is reported)
* Added two new preference settings, one to enable generation of `lastCheckin___` time/date stamp events, and the other to enable `lastClear___`, `lastDetected___`, and `lastTested___` time/date stamp events. NOTE: the default setting is DISABLED.
* Removed isStateChange: true in a number of instances to reduce the number of redundant repeat value events generated by the driver.
* Other fixes, reformatting, and reorganization of code